### PR TITLE
feat: add flatten structure for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ TL;DR
 - CTEs
 - columns: name and dtype (by referencing aliases)
 
-By default, schema suggestion is generated whenever a user hits "space".
+By default, schema + model suggestion is generated whenever a user hits "space".
 At this point, the syntax for the SQL query isn't complete and the plugin
 therefore uses a little bit of regex to "find/match" the selected schema.
 

--- a/lua/cmp-dbee/connection.lua
+++ b/lua/cmp-dbee/connection.lua
@@ -15,8 +15,8 @@ local Connection = {}
 function Connection:new()
   local cls = {
     current_connection_id = nil,
-    ---@type table<string, table>
     structure = {},
+    flatten_structure = {},
     columns = {},
     timeout_ms = 1000,
   }
@@ -84,6 +84,34 @@ function Connection:set_structure()
   vim.defer_fn(function()
     self:set_structure_async()
   end, self.timeout_ms)
+end
+
+function Connection:get_flatten_structure()
+  local exist = self.flatten_structure[self.current_connection_id]
+  if exist then
+    return exist
+  end
+
+  local flatten = {}
+  local structure = self.structure[self.current_connection_id]
+  if structure then
+    for _, node in ipairs(structure) do
+      if node.children then
+        for _, child in ipairs(node.children) do
+          print(vim.inspect(child))
+          local out = {
+            name = node.name .. "." .. child.name,
+            schema = node.name,
+            type = child.type,
+          }
+          table.insert(flatten, out)
+        end
+      end
+    end
+  end
+
+  self.flatten_structure[self.current_connection_id] = flatten
+  return flatten
 end
 
 function Connection:get_schemas()

--- a/lua/cmp-dbee/source.lua
+++ b/lua/cmp-dbee/source.lua
@@ -74,9 +74,10 @@ function source:get_completion()
     end
   end
 
-  -- extend with schemas from the connection
+  -- extend with schemas + tables from the connection
   -- so we don't modify the original list
   vim.list_extend(schemas, self.connection:get_schemas())
+  vim.list_extend(schemas, self.connection:get_flatten_structure())
   return self:convert_many_to_completion_items(schemas)
 end
 
@@ -98,7 +99,19 @@ function source:get_documentation(item)
 
   -- found model => show type
   if item.schema and item.name then
-    return "type: " .. item.type .. "\n" .. "schema: " .. item.schema
+    local name = item.name
+    if name:match("%.") then
+      name = name:match("%.(.*)")
+    end
+    -- stylua: ignore
+    return "name: "
+      .. name
+      .. "\n"
+      .. "type: "
+      .. item.type
+      .. "\n"
+      .. "schema: "
+      .. item.schema
   end
 
   return "unknown => open an issue!"


### PR DESCRIPTION
New feature which allows tables/views/functions to be autocompleted out of the box but with addition of schema as prefix.

For example:
I've a table in `flights` schema which is called `seattle...` something. Now when I start to write `seattle` it still finds this table but adds the schema as a prefix:
<img width="813" alt="image" src="https://github.com/MattiasMTS/cmp-dbee/assets/86059470/759b69a3-332b-4f0a-bcb0-cd0a41dafed1">

so when "accepting" this autocompletion -> the schema.table is accepted
<img width="483" alt="image" src="https://github.com/MattiasMTS/cmp-dbee/assets/86059470/2b30c601-0803-4ee5-a115-6277c0485746">

This allows tables/views to be prompted out of the box but without causing ambiguity later on when executing the query.

--- 
**EDIT**
I realize now that I need to make a new video..