### PR TITLE
Update for event name changes in nvim-dbee

### DIFF
--- a/lua/cmp-dbee/connection.lua
+++ b/lua/cmp-dbee/connection.lua
@@ -68,9 +68,9 @@ function Connection:new(cfg)
   end)
 
   -- listen to all database switch events
-  api.register_event_listener("current_database_changed", function(data)
+  api.register_event_listener("database_selected", function(data)
     local on_current_database_changed = function()
-      if cls.db_name ~= data.db_name then
+      if cls.db_name ~= data.database_name then
         cls:set_structure()
       end
     end


### PR DESCRIPTION
The schema/tables completion list isn't updating when switching databases. It looks like the event name was changed in nvim-dbee. I was able to get it updating again with this change.