### PR TITLE
Add class function to check availability

### DIFF
--- a/lua/cmp-dbee/source.lua
+++ b/lua/cmp-dbee/source.lua
@@ -3,11 +3,11 @@ local source = {}
 
 local dbee = require("dbee")
 local handler = require("cmp-dbee.handler")
-local is_available = dbee.api.core.is_loaded() and dbee.api.ui.is_loaded()
 
 --- Constructor for nvim-cmp source
 ---@param cfg Config
 function source:new(cfg)
+  local is_available = self:is_available()
   local cls = { handler = handler:new(cfg, is_available) }
   setmetatable(cls, self)
   self.__index = self
@@ -27,7 +27,7 @@ function source:complete(_, callback)
 end
 
 function source:is_available()
-  return is_available
+  return dbee.api.core.is_loaded() and dbee.api.ui.is_loaded()
 end
 
 function source:get_trigger_characters()


### PR DESCRIPTION
This is an implementation to solve https://github.com/MattiasMTS/cmp-dbee/issues/22

The issue is that the `is_available` is evaluated at startup, when the plugin is loaded. At this time, `dbee` is not loaded and it is always set to `false`.

We can use the added function independently as well as inside of the constructor of the source itself. This way, we will actually try to load the source with the `setup()` function after we have opened the Dbee client.

Not sure if this is the intention, but for the completion to work, one has to run the setup after `Dbee` is open. Hence, I have this auto command to trigger completion for `SQL` files
```lua
local auGroup = vim.api.nvim_create_augroup("nvim-dbee-custom", {clear = true})
vim.api.nvim_create_autocmd("FileType", {
    group = auGroup,
    pattern = "sql",
    callback = function()
        require('cmp').setup.filetype({"sql", "mysql", "plsql"}, {
            sources = require('cmp').config.sources{
                { name = 'cmp-dbee' }
            }
        })
        require("cmp-dbee").setup({})
    end
})
```
Since this already checks if `dbee` is loaded, it won't effect performance of any random `sql` files being opened.

Let me know what you think @MattiasMTS 